### PR TITLE
Fix for text including brackets being included in at mention

### DIFF
--- a/packages/atmention-core/src/constants.ts
+++ b/packages/atmention-core/src/constants.ts
@@ -12,7 +12,7 @@ export default {
     '([^)\n]+)' +
     '\\]' +
     '\\(' +
-    '([^\\]\n]+)' +
+    '([^\\]\)\n]+)' +
     '\\)',
 
   // determines when to show the suggestions overlay


### PR DESCRIPTION
Current regex behaviour (https://regex101.com/r/gR79Ua/3),
Desired behaviour (https://regex101.com/r/gR79Ua/4)